### PR TITLE
Change to extra-paths in dev alias to keep the src path

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:aliases
- {:dev {:paths ["dev"]}
+ {:dev {:extra-paths ["dev"]}
   :nextjournal/clerk
   {:extra-deps {io.github.nextjournal/clerk {:git/sha "c4f5fe11f7b4f1141654c7082f04d737f7192f1d"}}
    :extra-paths ["notebooks"]


### PR DESCRIPTION
Fixes `Could not locate nextjournal/clerk_slideshow__init.class, nextjournal/clerk_slideshow.clj or nextjournal/clerk_slideshow.cljc on classpath` when:

1. `clj -A:dev:nextjournal/clerk`
2. `(clerk/show! 'simple-slideshow)`